### PR TITLE
Restored .gitignore and removed timing.csv file generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+.nextflow/*
+.nextflow.log*
+pdj_results/
+models/
+
+# Bindsweeper
+bindsweeper.config
+results/
+bindsweeper/**/__pycache__/
+bindsweeper/**/*.py[cod]
+bindsweeper/**/*.egg-info
+bindsweeper/**/dist/
+bindsweeper/**/build/
+bindsweeper/.nextflow/**
+bindsweeper/quick_test_results/**
+bindsweeper/test_output/**
+bindsweeper/bindsweeper.config
+bindsweeper/quick_test_results/**
+bindsweeper/test_output/**
+bindsweeper/**/.nextflow/**

--- a/nextflow.config
+++ b/nextflow.config
@@ -492,13 +492,3 @@ process {
             containerOptions = "--bind ${projectDir} --bind ${projectDir}/scripts:/scripts"
         }
 }
-// TRACING
-def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
-trace {
-    enabled = true
-    fields = 'task_id,name,status,submit,start,complete,duration,realtime'
-    file = "trace_${trace_timestamp}.csv"
-    sep = ','
-    overwrite = true 
-}
-


### PR DESCRIPTION
Restored .gitignore that was missed in the public release.

I have also removed the function in nextflow.config that generates timing data in CSV files. Users have complained that this clutters their workspace.