### PR TITLE
Adding a unique date/time to output directory name

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -14,7 +14,7 @@ params {
     seqs_per_design   = 8
 
     // Output directory for results. Existing results in this directory will be overwritten. 
-    // To generate a unique directory name with date/time use a Groovy function e.g "pdj_results/${new Date().format('yyyyMMdd_HHmmss')}""
+    // To generate a unique directory name with date/time use a Groovy function e.g "pdj_results/${new Date().format('yyyyMMdd_HHmmss')}"
     out_dir           = "pdj_results"
 
     //////////////////////////////

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,8 +13,9 @@ params {
     // Number of sequences to generate per RFdiffusion design
     seqs_per_design   = 8
 
-    // Output directory for results. Existing results in this directory will be overwritten.
-    out_dir           = "${projectDir}/pdj_results"
+    // Output directory for results. Existing results in this directory will be overwritten. 
+    // To generate an unique directory name with date/time use a Groovy function e.g "pdj_results/${new Date().format('yyyyMMdd_HHmmss')}""
+    out_dir           = "pdj_results"
 
     //////////////////////////////
     // MODE SPECIFIC PARAMETERS //

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,7 +14,7 @@ params {
     seqs_per_design   = 8
 
     // Output directory for results. Existing results in this directory will be overwritten. 
-    // To generate an unique directory name with date/time use a Groovy function e.g "pdj_results/${new Date().format('yyyyMMdd_HHmmss')}""
+    // To generate a unique directory name with date/time use a Groovy function e.g "pdj_results/${new Date().format('yyyyMMdd_HHmmss')}""
     out_dir           = "pdj_results"
 
     //////////////////////////////


### PR DESCRIPTION
@nskirk suggested a short function to add to the end of the output directory name that will give a unique time and date:
`pdj_results/${new Date().format('yyyyMMdd_HHmmss')}`

This prevents outputs from being overwritten. I've added it as a suggestion in the comments.

I noticed BindSweeper was not parsing Groovy functions, so I removed the '${projectDir}' prefix from the default out_dir name. It is still used for the seqera profiles, for which BindSweeper is not relevant.