### PR TITLE
fix boltz filter typo

### DIFF
--- a/scripts/filter_boltz.py
+++ b/scripts/filter_boltz.py
@@ -22,7 +22,7 @@ def parse_arguments():
                     help='Minimum confidence score')
     parser.add_argument('--boltz-min-ptm', type=float, 
                     help='Minimum pTM score')
-    parser.add_argument('--boltz-min-ptm_interface', type=float,
+    parser.add_argument('--boltz-min-ptm-interface', type=float,
                     help='Minimum interface pTM score')
     parser.add_argument('--boltz-min-plddt', type=float,
                     help='Minimum complex pLDDT score')


### PR DESCRIPTION
Minor typo fix for boltz filtering:

```
filter_boltz.py: error: unrecognized arguments: --boltz-min-ptm-interface 
```

"_" delimited nextflow param gets sanitized to "-" but python script expects mixed delimiter: --boltz-min-ptm_interface

Modified python script to expect "-" delimited argument.