### PR TITLE
Fix MacOS incompatible xargs flag

### DIFF
--- a/bindsweeper/pyproject.toml
+++ b/bindsweeper/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bindsweeper"
-version = "2.2.0" 
+version = "2.2.1" 
 authors = [
     { name = "Dylan Silke", email = "silke.dy@wehi.edu.au"},
     { name = "Josh Hardy", email = "hardy.j@wehi.edu.au"}

--- a/nextflow.config
+++ b/nextflow.config
@@ -688,6 +688,6 @@ manifest {
     description     = 'Nextflow pipeline for protein design using RFdiffusion, BindCraft, ProteinMPNN, FullAtom MPNN, AlphaFold2 Initial-Guess, and Boltz-2.'
     mainScript      = 'main.nf'
     nextflowVersion = '!>=24.04.0'
-    version         = '2.2.0'
+    version         = '2.2.1'
     doi             = '10.1101/2025.09.24.678028'
 }

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -176,7 +176,7 @@ if [ -d "mols" ]; then
     print_success "Boltz-2 mols directory already extracted, skipping..."
 else
     print_status "Extracting Boltz-2 molecular data... (only amino acids are needed for protein design)"
-    tar -tf mols.tar | grep -E 'mols/(ALA|ARG|ASN|ASP|CYS|GLU|GLN|GLY|HIS|ILE|LEU|LYS|MET|PHE|PRO|SER|THR|TRP|TYR|VAL|UNK)\.pkl$' | xargs -d '\n' -I {} tar -xvf mols.tar "{}" || exit 1
+    tar -tf mols.tar | grep -E 'mols/(ALA|ARG|ASN|ASP|CYS|GLU|GLN|GLY|HIS|ILE|LEU|LYS|MET|PHE|PRO|SER|THR|TRP|TYR|VAL|UNK)\.pkl$' | tr '\n' '\0' | xargs -0 -I {} tar -xvf mols.tar "{}" || exit 1
     rm -f mols.tar
     print_success "Boltz-2 molecular data extracted!"
 fi


### PR DESCRIPTION
A user reported that the download_models.sh script failed on macosx due to osx xargs not having a -d option (#37)

Changed xargs -d '\n' → tr '\n' '\0' | xargs -0:
- xargs -d '\n' is a GNU extension unavailable on macOS BSD xargs
- xargs -0 (null-delimited) is portable across both platforms
- tr '\n' '\0' converts newline-separated filenames from grep into null-terminated ones that xargs -0 expects